### PR TITLE
Add new decorators and support multiple responses

### DIFF
--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -116,7 +116,7 @@ class Object(Field):
                 key: serialize_schema(schema)
                 for key, schema in self.cls.__dict__.items()
                 if not key.startswith("_")
-                },
+            },
             **super().serialize()
         }
 
@@ -185,6 +185,7 @@ class RouteSpec:
     operation = None
     blueprint = None
     tags = None
+    header = None
 
     def __init__(self):
         self.tags = []
@@ -195,7 +196,7 @@ route_specs = defaultdict(RouteSpec)
 
 
 def route(summary=None, description=None, consumes=None, produces=None,
-          consumes_content_type=None, produces_content_type=None):
+          consumes_content_type=None, produces_content_type=None, header=None):
     def inner(func):
         route_spec = route_specs[func]
 
@@ -211,7 +212,8 @@ def route(summary=None, description=None, consumes=None, produces=None,
             route_spec.consumes_content_type = consumes_content_type
         if produces_content_type is not None:
             route_spec.produces_content_type = produces_content_type
-
+        if header is not None:
+            route_spec.header = header
         return func
     return inner
 
@@ -251,5 +253,12 @@ def produces(*args, content_type=None):
 def tag(name):
     def inner(func):
         route_specs[func].tags.append(name)
+        return func
+    return inner
+
+
+def header(*args):
+    def inner(func):
+        route_specs[func].header = args
         return func
     return inner

--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -72,8 +72,11 @@ class Dictionary(Field):
     def serialize(self):
         return {
             "type": "object",
-            "properties": {key: serialize_schema(schema) for key, schema in self.fields.items()},
-            **super().serialize()
+            "properties": {key: serialize_schema(schema)
+                           if not isinstance(schema, str)
+                           else {"type": "string"}
+                           for key, schema in self.fields.items()},
+            ** super().serialize()
         }
 
 

--- a/sanic_openapi/openapi.py
+++ b/sanic_openapi/openapi.py
@@ -128,7 +128,7 @@ def build_spec(app, loop):
                 'parameters': path_parameters + query_string_parameters + body_parameters +
                 header_parameters
             }
-            if isinstance(route_spec.produces, dict):
+            if route_spec.produces:
                 responses = {'responses': {}}
                 for k in list(route_spec.produces.keys()):
                     responses['responses'].update({
@@ -140,15 +140,6 @@ def build_spec(app, loop):
                     })
                 endpoint.update(responses)
                 endpoint = remove_nulls(endpoint)
-            else:
-                responses = {'responses': {
-                    "200": {
-                        "description": None,
-                        "examples": None,
-                        "schema": serialize_schema(route_spec.produces) if route_spec.produces else None
-                    }
-                }}
-                endpoint.update(responses)
             methods[_method.lower()] = endpoint
 
         uri_parsed = uri

--- a/sanic_openapi/openapi.py
+++ b/sanic_openapi/openapi.py
@@ -102,21 +102,22 @@ def build_spec(app, loop):
                 } for header in route_spec.header]
 
             if route_spec.consumes:
-                if _method in ('GET', 'DELETE', 'POST'):
-                    spec = serialize_schema(route_spec.consumes)
-                    if 'properties' in spec:
-                        for name, prop_spec in spec['properties'].items():
-                            query_string_parameters.append({
-                                **prop_spec,
-                                'in': 'query',
-                                'name': name,
-                            })
-                else:
-                    body_parameters.append({
-                        **serialize_schema(route_spec.consumes),
-                        'in': 'body',
-                        'name': 'body',
-                    })
+                for consume in route_spec.consumes:
+                    if isinstance(consume, dict):
+                        spec = serialize_schema(consume)
+                        if 'properties' in spec:
+                            for name, prop_spec in spec['properties'].items():
+                                query_string_parameters.append({
+                                    **prop_spec,
+                                    'in': 'query',
+                                    'name': name,
+                                })
+                    else:
+                        body_parameters.append({
+                            **serialize_schema(consume),
+                            'in': 'body',
+                            'name': 'body',
+                        })
 
             endpoint = {
                 'operationId': route_spec.operation or route.name,

--- a/sanic_openapi/openapi.py
+++ b/sanic_openapi/openapi.py
@@ -138,7 +138,7 @@ def build_spec(app, loop):
                             "schema": serialize_schema(route_spec.produces[k]) if route_spec.produces[k] else None
                         }
                     })
-                endpoint['responses'] = responses
+                endpoint.update(responses)
                 endpoint = remove_nulls(endpoint)
             else:
                 responses = {'responses': {
@@ -148,7 +148,7 @@ def build_spec(app, loop):
                         "schema": serialize_schema(route_spec.produces) if route_spec.produces else None
                     }
                 }}
-                endpoint['responses'] = responses
+                endpoint.update(responses)
             methods[_method.lower()] = endpoint
 
         uri_parsed = uri

--- a/sanic_openapi/openapi.py
+++ b/sanic_openapi/openapi.py
@@ -130,7 +130,7 @@ def build_spec(app, loop):
             }
             if route_spec.produces:
                 responses = {'responses': {}}
-                for k in list(route_spec.produces.keys()):
+                for k in route_spec.produces.keys():
                     responses['responses'].update({
                         k: {
                             "description": None,


### PR DESCRIPTION
Add new decorator @doc.header(*args), will accept the params as header names.
Add query parameter support for POST method.
Add multiple responses support in order to show valid and invalid response schemas. Usage:
@doc.produces({
    200: response.resp({'Group1': {'projects': doc.List(str)}}, 'Normal'),
    400: response.resp({'Group1': {'projects': doc.List(str)}}, 'Normal'),
})
Fix when the dict has no nested dict, json schema is not shown properly, now they will display on the page.
Add support for multiple consumes, dict type for query param and model class for body. Usage:
@doc.consumes([{'query': str}, Body])