### PR TITLE
Fix broken Swagger links

### DIFF
--- a/sanic_openapi/ui/index.html
+++ b/sanic_openapi/ui/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <title>Swagger UI</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
-  <link rel="stylesheet" type="text/css" href="./swagger/swagger-ui.css" >
+  <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
   <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
   <style>
@@ -67,8 +67,8 @@
 
 <div id="swagger-ui"></div>
 
-<script src="./swagger/swagger-ui-bundle.js"> </script>
-<script src="./swagger/swagger-ui-standalone-preset.js"> </script>
+<script src="./swagger-ui-bundle.js"> </script>
+<script src="./swagger-ui-standalone-preset.js"> </script>
 <script>
 window.onload = function() {
   var url = '/openapi/spec.json';


### PR DESCRIPTION
These two commits [86f516b16bdbe16d840523a736a2c4987916c879](https://github.com/channelcat/sanic-openapi/commit/86f516b16bdbe16d840523a736a2c4987916c879) and [dc98dcfacc15a575ebf4ba1cfbdeeb689be98f1e](https://github.com/channelcat/sanic-openapi/commit/dc98dcfacc15a575ebf4ba1cfbdeeb689be98f1e) seem to break Swagger UI. This PR is to fix the Swagger UI.