### PR TITLE
https://github.com/channelcat/sanic-openapi/issues/51

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ from sanic_openapi import doc
 @app.get("/user/<user_id:int>")
 @doc.summary("Fetches a user by ID")
 @doc.produces({ "user": { "name": str, "id": int } })
+@doc.response(404, 'Not found')
 async def get_user(request, user_id):
     ...
 
 @app.post("/user")
 @doc.summary("Creates a user")
 @doc.consumes({"user": { "name": str }}, location="body")
+@doc.response(201, 'Created')
 async def create_user(request):
     ...
 ```

--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -191,6 +191,7 @@ def serialize_schema(schema):
 
 class RouteSpec(object):
     consumes = None
+    responses = None
     consumes_content_type = None
     produces = None
     produces_content_type = None
@@ -204,6 +205,7 @@ class RouteSpec(object):
     def __init__(self):
         self.tags = []
         self.consumes = []
+        self.responses = {}
         super().__init__()
 
 
@@ -274,6 +276,18 @@ def consumes(*args, content_type=None, location='query', required=False):
                 field = RouteField(arg, location, required)
                 route_specs[func].consumes.append(field)
                 route_specs[func].consumes_content_type = content_type
+        return func
+    return inner
+
+
+def responses(code, description=None, examples=None, schema=None):
+    def inner(func):
+        route_specs[func].responses[code] = {
+            'description': description,
+            'examples': examples,
+            'schema': schema
+        }
+
         return func
     return inner
 

--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -280,7 +280,7 @@ def consumes(*args, content_type=None, location='query', required=False):
     return inner
 
 
-def responses(code, description=None, examples=None, schema=None):
+def response(code, description=None, examples=None, schema=None):
     def inner(func):
         route_specs[func].responses[code] = {
             'description': description,

--- a/sanic_openapi/openapi.py
+++ b/sanic_openapi/openapi.py
@@ -125,7 +125,7 @@ def build_spec(app, loop):
                 'produces': produces_content_types,
                 'tags': route_spec.tags or None,
                 'parameters': route_parameters,
-                'responses': {
+                'responses': route_spec.responses or {
                     "200": {
                         "description": None,
                         "examples": None,

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -10,8 +10,8 @@ def test_responses():
     app.blueprint(openapi_blueprint)
 
     @app.put('/test', strict_slashes=True)
-    @doc.responses(201, 'Created')
-    @doc.responses(404, 'Not found')
+    @doc.response(201, 'Created')
+    @doc.response(404, 'Not found')
     def test(request):
         return json({"test": True})
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,27 @@
+from json import loads as json_loads
+from sanic import Sanic
+from sanic.response import json
+from sanic_openapi import openapi_blueprint, doc
+
+
+def test_responses():
+    app = Sanic('test_responses')
+
+    app.blueprint(openapi_blueprint)
+
+    @app.put('/test', strict_slashes=True)
+    @doc.responses(201, 'Created')
+    @doc.responses(404, 'Not found')
+    def test(request):
+        return json({"test": True})
+
+    request, response = app.test_client.get('/openapi/spec.json')
+
+    response_schema = json_loads(response.body.decode())
+
+    responses = response_schema['paths']['/test']['put']['responses']
+
+    assert str(201) in responses
+    assert str(404) in responses
+
+test_responses()


### PR DESCRIPTION
replace default responses with status code 200 by ones from decorator:
@doc.response(201, 'Created')
@doc.response(404, 'Not found')
def ...
if no responses declared by decorator default one is used:
{ "200": 
    {"description": None,
     "examples": None,
     "schema": serialize_schema(route_spec.produces) if route_spec.produces else None
     }
}