### PR TITLE
Adding response decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,14 @@ app.config.API_TERMS_OF_SERVICE = 'Use with caution!'
 app.config.API_PRODUCES_CONTENT_TYPES = ['application/json']
 app.config.API_CONTACT_EMAIL = 'channelcat@gmail.com'
 ```
+
+### Additional documentation strings
+
+A new response decorator will allow you to add a series of responses
+supporting a status code, description and optional example.
+
+```python
+@doc.response('200', 'Successful Operation', {'handle': '1195ff38-d2e2-11e7-8edb-bcaec5447bf4'})
+@doc.response('404', 'File not found')
+@doc.response('500', 'Application erroor')
+```

--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -302,4 +302,3 @@ def response(code, description=None, examples=None):
         route_specs[func].responses[code] = {'description': description, 'example': examples}
         return func
     return inner
-

--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -302,3 +302,4 @@ def response(code, description=None, examples=None):
         route_specs[func].responses[code] = {'description': description, 'example': examples}
         return func
     return inner
+

--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -200,10 +200,12 @@ class RouteSpec(object):
     blueprint = None
     tags = None
     exclude = None
+    responses = None
 
     def __init__(self):
         self.tags = []
         self.consumes = []
+        self.responses = {}
         super().__init__()
 
 
@@ -291,5 +293,12 @@ def produces(*args, content_type=None):
 def tag(name):
     def inner(func):
         route_specs[func].tags.append(name)
+        return func
+    return inner
+
+
+def response(code, description=None, examples=None):
+    def inner(func):
+        route_specs[func].responses[code] = {'description': description, 'example': examples}
         return func
     return inner

--- a/sanic_openapi/openapi.py
+++ b/sanic_openapi/openapi.py
@@ -117,6 +117,13 @@ def build_spec(app, loop):
 
                 route_parameters.append(route_param)
 
+            if '200' not in route_spec.responses:
+                route_spec.responses['200'] = {
+                    "description": 'successful operation',
+                    "example": None,
+                    "schema": serialize_schema(route_spec.produces) if route_spec.produces else None
+                }
+
             endpoint = remove_nulls({
                 'operationId': route_spec.operation or route.name,
                 'summary': route_spec.summary,
@@ -125,13 +132,7 @@ def build_spec(app, loop):
                 'produces': produces_content_types,
                 'tags': route_spec.tags or None,
                 'parameters': route_parameters,
-                'responses': {
-                    "200": {
-                        "description": None,
-                        "examples": None,
-                        "schema": serialize_schema(route_spec.produces) if route_spec.produces else None
-                    }
-                },
+                'responses': route_spec.responses
             })
 
             methods[_method.lower()] = endpoint


### PR DESCRIPTION
This is a relatively trivial change that adds a 'response' decorator for documenting exit status codes. Consider for example the following that might go in a blueprint header;
```
@doc.response('200', 'Successful Operation', {'handle': '1195ff38-d2e2'})
@doc.response('404', 'File not found')
@doc.response('500', 'Application erroor')
```
This works well with the swagger interface and supports both description and example options.