### PR TITLE
Fix travis-ci build status url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sanic OpenAPI
 
-[![Build Status](https://travis-ci.org/channelcat/sanic-openapi.svg?branch=master)](https://travis-ci.org/channelcat/sanic-openapi)
+[![Build Status](https://travis-ci.org/huge-success/sanic-openapi.svg?branch=master)](https://travis-ci.org/huge-success/sanic-openapi)
 [![PyPI](https://img.shields.io/pypi/v/sanic-openapi.svg)](https://pypi.python.org/pypi/sanic-openapi/)
 [![PyPI](https://img.shields.io/pypi/pyversions/sanic-openapi.svg)](https://pypi.python.org/pypi/sanic-openapi/)
 


### PR DESCRIPTION
After switch to new repository owner, we also need to switch travis-ci build status url. 