### PR TITLE
Fix url of static files in ui/index.html

### DIFF
--- a/sanic_openapi/ui/index.html
+++ b/sanic_openapi/ui/index.html
@@ -5,9 +5,9 @@
   <meta charset="UTF-8">
   <title>Swagger UI</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
-  <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
-  <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+  <link rel="stylesheet" type="text/css" href="./swagger/swagger-ui.css" >
+  <link rel="icon" type="image/png" href="./swagger/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="./swagger/favicon-16x16.png" sizes="16x16" />
   <style>
     html
     {
@@ -67,14 +67,14 @@
 
 <div id="swagger-ui"></div>
 
-<script src="./swagger-ui-bundle.js"> </script>
-<script src="./swagger-ui-standalone-preset.js"> </script>
+<script src="./swagger/swagger-ui-bundle.js"> </script>
+<script src="./swagger/swagger-ui-standalone-preset.js"> </script>
 <script>
 window.onload = function() {
 
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "swagger.json",
+    url: "/swagger/swagger.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
Hi there,
It's glad to see `sanic-openapi` back. But when I use `sanic-openapi==0.5.0` from PyPI, It seems not working now. It looks like url of static files not correct in `ui/index.html`.

test.py:
```python
from sanic import Sanic
from sanic.response import json

from sanic_openapi import doc, swagger_blueprint

app = Sanic()
app.blueprint(swagger_blueprint)

@app.get("/user/<user_id:int>")
@doc.summary("Fetches a user by ID")
@doc.produces({ "user": { "name": str, "id": int } })
async def get_user(request, user_id):
    user = {
        'name': 'Foobar',
        'id': 0
    }
    return json(user)


if __name__ == '__main__':
    app.run()

```

Access to http://localhost:8000/swagger, It is a blank page with error in console:
```
The script from “http://localhost:8000/swagger-ui-standalone-preset.js” was loaded even though its MIME type (“text/plain”) is not a valid JavaScript MIME type.[Learn More] swagger
The script from “http://localhost:8000/swagger-ui-bundle.js” was loaded even though its MIME type (“text/plain”) is not a valid JavaScript MIME type.[Learn More] swagger
Loading failed for the <script> with source “http://localhost:8000/swagger-ui-bundle.js”. swagger:70:1
The script from “http://localhost:8000/swagger-ui-standalone-preset.js” was loaded even though its MIME type (“text/plain”) is not a valid JavaScript MIME type.[Learn More] swagger
Loading failed for the <script> with source “http://localhost:8000/swagger-ui-standalone-preset.js”. swagger:71:1
ReferenceError: SwaggerUIBundle is not defined[Learn More] swagger:76:9
Source map error: TypeError: NetworkError when attempting to fetch resource.
Resource URL: moz-extension://709274c2-6622-46b5-9fd1-f6b522d58984/node_modules/webextension-polyfill/dist/browser-polyfill.js
Source Map URL: browser-polyfill.js.map[Learn More]
```

And the output from `sanic`:
```
[2019-03-28 12:29:17 +0800] [8880] [INFO] Goin' Fast @ http://127.0.0.1:8000
[2019-03-28 12:29:17 +0800] [8880] [INFO] Starting worker [8880]
[2019-03-28 12:29:19 +0800] - (sanic.access)[INFO][127.0.0.1:47694]: GET http://localhost:8000/swagger  200 3497
[2019-03-28 12:29:19 +0800] [8880] [ERROR] Exception occurred while handling uri: 'http://localhost:8000/swagger-ui.css'
Traceback (most recent call last):
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/app.py", line 893, in handle_request
    handler, args, kwargs, uri = self.router.get(request)
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/router.py", line 407, in get
    return self._get(request.path, request.method, "")
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/router.py", line 469, in _get
    raise NotFound("Requested URL {} not found".format(url))
sanic.exceptions.NotFound: Requested URL /swagger-ui.css not found
[2019-03-28 12:29:19 +0800] - (sanic.access)[INFO][127.0.0.1:47694]: GET http://localhost:8000/swagger-ui.css  404 46
[2019-03-28 12:29:19 +0800] [8880] [ERROR] Exception occurred while handling uri: 'http://localhost:8000/swagger-ui-bundle.js'
Traceback (most recent call last):
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/app.py", line 893, in handle_request
    handler, args, kwargs, uri = self.router.get(request)
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/router.py", line 407, in get
    return self._get(request.path, request.method, "")
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/router.py", line 469, in _get
    raise NotFound("Requested URL {} not found".format(url))
sanic.exceptions.NotFound: Requested URL /swagger-ui-bundle.js not found
[2019-03-28 12:29:19 +0800] - (sanic.access)[INFO][127.0.0.1:47696]: GET http://localhost:8000/swagger-ui-bundle.js  404 52
[2019-03-28 12:29:19 +0800] [8880] [ERROR] Exception occurred while handling uri: 'http://localhost:8000/swagger-ui-standalone-preset.js'
Traceback (most recent call last):
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/app.py", line 893, in handle_request
    handler, args, kwargs, uri = self.router.get(request)
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/router.py", line 407, in get
    return self._get(request.path, request.method, "")
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/router.py", line 469, in _get
    raise NotFound("Requested URL {} not found".format(url))
sanic.exceptions.NotFound: Requested URL /swagger-ui-standalone-preset.js not found
[2019-03-28 12:29:19 +0800] - (sanic.access)[INFO][127.0.0.1:47698]: GET http://localhost:8000/swagger-ui-standalone-preset.js  404 63
[2019-03-28 12:29:19 +0800] [8880] [ERROR] Exception occurred while handling uri: 'http://localhost:8000/swagger-ui-standalone-preset.js'
Traceback (most recent call last):
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/app.py", line 893, in handle_request
    handler, args, kwargs, uri = self.router.get(request)
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/router.py", line 407, in get
    return self._get(request.path, request.method, "")
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/router.py", line 469, in _get
    raise NotFound("Requested URL {} not found".format(url))
sanic.exceptions.NotFound: Requested URL /swagger-ui-standalone-preset.js not found
[2019-03-28 12:29:19 +0800] - (sanic.access)[INFO][127.0.0.1:47694]: GET http://localhost:8000/swagger-ui-standalone-preset.js  404 63
[2019-03-28 12:29:19 +0800] [8880] [ERROR] Exception occurred while handling uri: 'http://localhost:8000/favicon-16x16.png'
Traceback (most recent call last):
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/app.py", line 893, in handle_request
    handler, args, kwargs, uri = self.router.get(request)
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/router.py", line 407, in get
    return self._get(request.path, request.method, "")
  File "/home/jacob/.pyenv/versions/3.6.8/envs/sanic-openapi/lib/python3.6/site-packages/sanic/router.py", line 469, in _get
    raise NotFound("Requested URL {} not found".format(url))
sanic.exceptions.NotFound: Requested URL /favicon-16x16.png not found
[2019-03-28 12:29:19 +0800] - (sanic.access)[INFO][127.0.0.1:47694]: GET http://localhost:8000/favicon-16x16.png  404 49
```