### PR TITLE
Create swagger configuration route

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ app.config.API_SECURITY_DEFINITIONS = {
 
 ```
 
+### Set Swagger-UI configuration parameters
+
+Here you can set any configuration described in the swagger-ui documentation
+
+```python
+app.config.SWAGGER_UI_CONFIGURATION = {
+    'validatorUrl': None, # Disable Swagger validator
+    'displayRequestDuration': True,
+    'docExpansion': 'full'
+}
+```
+
 ### Set responses for different HTTP status codes
 
 ```python

--- a/sanic_openapi/swagger.py
+++ b/sanic_openapi/swagger.py
@@ -215,7 +215,4 @@ def config(request):
     if hasattr(request.app.config, 'SWAGGER_UI_CONFIGURATION'):
         options = getattr(request.app.config, 'SWAGGER_UI_CONFIGURATION')
 
-    if hasattr(request.app.config, 'API_VALIDATOR_URL'):
-        options['validatorUrl'] = getattr(request.app.config, 'API_VALIDATOR_URL')
-
     return json(options)

--- a/sanic_openapi/swagger.py
+++ b/sanic_openapi/swagger.py
@@ -206,3 +206,16 @@ def build_spec(app, loop):
 @blueprint.route('/swagger.json')
 def spec(request):
     return json(_spec)
+
+
+@blueprint.route('/swagger-config')
+def config(request):
+    options = {}
+
+    if hasattr(request.app.config, 'SWAGGER_UI_CONFIGURATION'):
+        options = getattr(request.app.config, 'SWAGGER_UI_CONFIGURATION')
+
+    if hasattr(request.app.config, 'API_VALIDATOR_URL'):
+        options['validatorUrl'] = getattr(request.app.config, 'API_VALIDATOR_URL')
+
+    return json(options)

--- a/sanic_openapi/ui/index.html
+++ b/sanic_openapi/ui/index.html
@@ -40,6 +40,7 @@
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
         url: "./swagger.json",
+        configUrl: './swagger-config',
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
Closes #24.

In addition to adding the 'API_VALIDATOR_URL' configuration that we discussed, I took the opportunity to also make all the swagger-ui configuration customizable.

This way the user can set any configuration described in [https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/).

Example of code:
`
app.config.SWAGGER_UI_CONFIGURATION = {
    'validatorUrl': None,
    'displayRequestDuration': True,
    'docExpansion': 'full'
}
`

What do you guys think? 
@hampsterx @chenjr0719 