### PR TITLE
Remove swagger endpoints from swagger json

### DIFF
--- a/sanic_openapi/__init__.py
+++ b/sanic_openapi/__init__.py
@@ -1,4 +1,4 @@
-from .swagger import blueprint as swagger_blueprint
+from .swagger import swagger_blueprint
 
 __version__ = "0.5.3"
 __all__ = ["swagger_blueprint"]

--- a/sanic_openapi/swagger.py
+++ b/sanic_openapi/swagger.py
@@ -10,20 +10,20 @@ from .doc import RouteSpec, definitions
 from .doc import route as doc_route
 from .doc import route_specs, serialize_schema
 
-blueprint = Blueprint("swagger", url_prefix="/swagger")
+swagger_blueprint = Blueprint("swagger", url_prefix="/swagger")
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 dir_path = os.path.abspath(dir_path + "/ui")
 
 
 # Redirect "/swagger" to "/swagger/"
-@blueprint.route("", strict_slashes=True)
+@swagger_blueprint.route("", strict_slashes=True)
 def index(request):
-    return redirect("{}/".format(blueprint.url_prefix))
+    return redirect("{}/".format(swagger_blueprint.url_prefix))
 
 
-blueprint.static("/", dir_path + "/index.html", strict_slashes=True)
-blueprint.static("/", dir_path)
+swagger_blueprint.static("/", dir_path + "/index.html", strict_slashes=True)
+swagger_blueprint.static("/", dir_path)
 
 
 _spec = {}
@@ -38,7 +38,7 @@ def remove_nulls(dictionary, deep=True):
     }
 
 
-@blueprint.listener("before_server_start")
+@swagger_blueprint.listener("before_server_start")
 def build_spec(app, loop):
     _spec["swagger"] = "2.0"
     _spec["info"] = {
@@ -96,7 +96,7 @@ def build_spec(app, loop):
     for uri, route in app.router.routes_all.items():
 
         # Ignore routes under swagger blueprint
-        if route.uri.startswith(blueprint.url_prefix):
+        if route.uri.startswith(swagger_blueprint.url_prefix):
             continue
 
         if "static" in route.name:
@@ -244,13 +244,13 @@ def build_spec(app, loop):
     _spec["paths"] = paths
 
 
-@blueprint.route("/swagger.json")
+@swagger_blueprint.route("/swagger.json")
 @doc_route(exclude=True)
 def spec(request):
     return json(_spec)
 
 
-@blueprint.route("/swagger-config")
+@swagger_blueprint.route("/swagger-config")
 def config(request):
     options = {}
 

--- a/sanic_openapi/swagger.py
+++ b/sanic_openapi/swagger.py
@@ -10,7 +10,7 @@ from .doc import RouteSpec, definitions
 from .doc import route as doc_route
 from .doc import route_specs, serialize_schema
 
-blueprint = Blueprint("swagger", url_prefix="swagger")
+blueprint = Blueprint("swagger", url_prefix="/swagger")
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 dir_path = os.path.abspath(dir_path + "/ui")
@@ -94,6 +94,10 @@ def build_spec(app, loop):
 
     paths = {}
     for uri, route in app.router.routes_all.items():
+
+        # Ignore routes under swagger blueprint
+        if route.uri.startswith(blueprint.url_prefix):
+            continue
 
         if "static" in route.name:
             # TODO: add static flag in sanic routes


### PR DESCRIPTION
**Describe what bug you fixed**
After merge #80, other routes which not static routes but under swagger blueprint also be documented. This PR fixes this issue and also rename the variable name of the swagger blueprint to avoid confisions.


**Checklist**

- [x] I've already read the [contributing guide](../../CONTRIBUTING.md).
- [x] I've run all tests and make sure all exists test cases are passed.
- [x] I've make sure this PR works with `Sanic-18.12` and `Python-3.5`.
