### PR TITLE
Add sanic 19.06 in tox

### DIFF
--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -50,7 +50,8 @@ def test_swagger_endpoint_redirect(app):
     assert response.status == 200
     assert response.content_type == "text/html"
     assert len(response.history) == 1
-    assert response.history[0].status == 302
+    status = getattr(response.history[0], 'status', getattr(response.history[0], 'status_code', None)) # For request-async compatibility
+    assert status == 302
     assert str(response.history[0].url).endswith("/swagger")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,26 @@
 [tox]
-
-envlist = {py35, py36, py37}-sanic{lts, 19.03.1}, check
+envlist = py35-sanic{lts, 19.03.1}, {py36, py37}-sanic{lts, 19.03.1, 19.06.0}, check
 
 
 [travis]
-
 python =
     3.5: py35
     3.6: py36, check
     3.7: py37
 
-[testenv]
 
+[testenv]
 deps =
     saniclts: sanic==18.12.0
     saniclts: aiohttp==3.5.4
     sanic19.03.1: sanic==19.03.1
     sanic19.03.1: aiohttp==3.5.4
+    sanic19.06.0: sanic==19.06.0
 
 commands =
     pip install -e .['test']
     pytest tests/ {posargs}
+
 
 [testenv:check]
 deps =


### PR DESCRIPTION
The `Sanic-19.06`  has been released. So, I add it to the tox envlist to make sure `sanic-openapi` can work with `Sanic-19.06`.