### PR TITLE
Bump to 0.5.4

### DIFF
--- a/sanic_openapi/__init__.py
+++ b/sanic_openapi/__init__.py
@@ -1,4 +1,4 @@
 from .swagger import swagger_blueprint
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 __all__ = ["swagger_blueprint"]


### PR DESCRIPTION
Version 0.5.3 doesn't contain commit 29ff8960edcdfb192670c05eb4fd8463da16f628 which fixes #114. Proposing a minor version bump (and subsequently update to PyPi) to add this fix for projects pulling the latest version of this package.