### PR TITLE
Basic support for TypedDicts (PEP 589)

### DIFF
--- a/docs/sanic_openapi/fields.md
+++ b/docs/sanic_openapi/fields.md
@@ -340,6 +340,15 @@ async def get_single_car(request):
 And the result:
 ![](../_static/images/fields/type_hinting.png)
 
+[TypedDicts](https://www.python.org/dev/peps/pep-0589/) are also supported. In the previous example, `Car` could be defined as:
+
+```python
+class Car(TypedDict):
+    make: str
+    model: str
+    year: int
+```
+
 
 ## Descriptive Field
 

--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -160,7 +160,7 @@ def serialize_schema(schema):
     # --------------------------------------------------------------- #
     # Class
     # --------------------------------------------------------------- #
-    if schema_type is type:
+    if issubclass(schema_type, type):
         if issubclass(schema, Field):
             return schema().serialize()
         elif schema is dict:


### PR DESCRIPTION
 #129 added support for type hinting-based docs. This adds basic support for [TypedDicts](https://www.python.org/dev/peps/pep-0589/), which were not supported because of their type.

Example:

```python
from sanic import Sanic
from sanic_openapi import doc, swagger_blueprint
from typing_extensions import TypedDict

app = Sanic()
app.blueprint(swagger_blueprint)

class Car(TypedDict):
    make: str
    model: str

@app.get("/car/<id:int>")
@doc.summary("Gets a car")
@doc.produces(Car)
async def get_car(request, car_id):
    car: Car = {"make": "Nissan", "model": "370Z"}
    # Alternative syntax: car = Car(make="Nissan", model="370Z")
    return json(car)

if __name__ == '__main__':
    app.run(host='0.0.0.0', port=8000)
```

[TypedDict inheritance](https://www.python.org/dev/peps/pep-0589/#inheritance) works, as well as Nested TypedDicts.

This PR provides basic support for TypedDict. Full support should probably analyze the [totality](https://www.python.org/dev/peps/pep-0589/#totality) of the TypedDict and set `required` to `True` or `False` accordingly.