### PR TITLE
support produces sqlalchemy DeclarativeMeta

### DIFF
--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -191,6 +191,8 @@ def serialize_schema(schema):
     else:
         if issubclass(schema_type, Field):
             return schema.serialize()
+        elif schema_type.__name__ == "DeclarativeMeta":
+            return Object(schema).serialize()
         elif schema_type is dict:
             return Dictionary(schema).serialize()
         elif schema_type is list:


### PR DESCRIPTION
The type of class inherit from `sqlalchemy.ext.declarative.declarative_base` will has type `sqlalchemy.ext.declarative.api.DeclarativeMeta`.

Currently, when use this class as @produces type, the output schema is {}.