### PR TITLE
type field is now placed inside of schema node for referenced objects

### DIFF
--- a/sanic_openapi/swagger.py
+++ b/sanic_openapi/swagger.py
@@ -213,6 +213,9 @@ def build_spec(app, loop):
                 if "$ref" in route_param:
                     route_param["schema"] = {"$ref": route_param["$ref"]}
                     del route_param["$ref"]
+                    if 'type' in route_param:
+                        route_param["schema"]['type'] = route_param['type']
+                        del route_param['type']
 
                 route_parameters.append(route_param)
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -95,11 +95,11 @@ class TestSchema:
             {"location": "body", "required": True, "content_type": "application/json"},
             [
                 {
-                    "type": "object",
                     "required": True,
                     "in": "body",
                     "name": "body",
-                    "schema": {"$ref": "#/definitions/TestSchema"},
+                    "schema": {"$ref": "#/definitions/TestSchema",
+                               "type": "object"},
                 }
             ],
         ),


### PR DESCRIPTION
I have repeatedly gotten an error when validating objects passed into @doc.consumes().  The error being:

    Failed validating 'oneOf' in schema['properties']['paths']['patternProperties']['^/']['properties']['post']['properties']['parameters']['items']:
    {'oneOf': [{'$ref': '#/definitions/parameter'},
               {'$ref': '#/definitions/jsonReference'}]}

Specific error instance:

    On instance['paths']['/endpointtest']['post']['parameters'][0]:
    {'description': 'data object description',
     'in': 'body',
     'name': 'PassedInDataObject',
     'required': True,
     'schema': {'$ref': '#/definitions/PassedInDataObject', 'x-scope': ['']},
     'type': 'object'}

When we look at the documentation for the [OpenAPI Specification](https://swagger.io) we can find several examples that show that the "type" field should be inside the "schema" block.  Whereas in the example above, the "type" field is at the same level as the "schema" block.

Here are some links to the examples listed in the [OpenAPI Specification](https://swagger.io) showing that "type" should be inside of "schema":

 * [Path Item Object Example](https://swagger.io/specification/#path-item-object-example)
 * [Operation Object Example](https://swagger.io/specification/#operation-object-example)
 * [Parameter Object Examples](https://swagger.io/specification/#parameter-object-examples)
 * [Request Body Examples](https://swagger.io/specification/#request-body-examples)
 * [Response Object Examples](https://swagger.io/specification/#response-object-examples)


### Solution:
In the sanic_openapi/swagger.py file, at line 213, we can see that if a field named "$ref" is dedicated, that a "schema" block is created, and the "$ref" is placed inside the "schema" block.
    
The new code I am submitting also checks to see if a "type" field exists, and then places it inside of the "schema" block as well.
