### PR TITLE
removed field 'type': 'object' from swagger json when using doc.Object()

### DIFF
--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -149,7 +149,6 @@ class Object(Field):
 
     def serialize(self):
         return {
-            "type": "object",
             "$ref": "#/definitions/{}".format(self.object_name),
             **super().serialize(),
         }

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -95,7 +95,6 @@ class TestSchema:
             {"location": "body", "required": True, "content_type": "application/json"},
             [
                 {
-                    "type": "object",
                     "required": True,
                     "in": "body",
                     "name": "body",
@@ -127,7 +126,7 @@ def test_consumes(app, consumes_args, consumes_kwargs, parameters):
         (
             [TestSchema],
             {"content_type": "application/json"},
-            {"200": {"schema": {"$ref": "#/definitions/TestSchema", "type": "object"}}},
+            {"200": {"schema": {"$ref": "#/definitions/TestSchema"}}},
         ),
     ],
 )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -319,7 +319,7 @@ class TestSchema:
         (datetime, {"type": "string", "format": "date-time"}),
         (doc.DateTime, {"type": "string", "format": "date-time"}),
         (doc.DateTime(), {"type": "string", "format": "date-time"}),
-        (TestSchema, {"$ref": "#/definitions/TestSchema", "type": "object"}),
+        (TestSchema, {"$ref": "#/definitions/TestSchema"}),
         (dict, {"type": "object", "properties": {}}),
         ({"foo": "bar"}, {"type": "object", "properties": {"foo": {}}}),
         (list, {"type": "array", "items": []}),


### PR DESCRIPTION
This is a new pull request based around the same issue as in [pull/145](https://github.com/huge-success/sanic-openapi/pull/145)

This version has two differences:
1) it implements the smaller change has discussed in the original request
2) the master branch was updated to contain the commits made after the original pull request was initially made.