### PR TITLE
fix: bump "__version__" to 0.6.1

### DIFF
--- a/sanic_openapi/__init__.py
+++ b/sanic_openapi/__init__.py
@@ -1,4 +1,4 @@
 from .swagger import swagger_blueprint
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __all__ = ["swagger_blueprint"]


### PR DESCRIPTION
A minor fix about `__version__` variable. @ahopkins This is my bad. :stuck_out_tongue_closed_eyes: 