### PR TITLE
Fix TypeError when Spec obj is not JSON serializable

### DIFF
--- a/sanic_openapi/spec.py
+++ b/sanic_openapi/spec.py
@@ -5,6 +5,7 @@ class Spec:
     swagger = "2.0"
 
     def __init__(self, app: Sanic) -> None:
+        self.swagger = self.__class__.swagger
         self.info = {
             "version": getattr(app.config, "API_VERSION", "1.0.0"),
             "title": getattr(app.config, "API_TITLE", "API"),
@@ -29,6 +30,10 @@ class Spec:
         self.securityDefinitions = getattr(app.config, "API_SECURITY_DEFINITIONS", None)
         self.security = getattr(app.config, "API_SECURITY", None)
 
+        self.definitions = {}
+        self.tags = []
+        self.paths = {}
+
     def add_definitions(self, definitions):
         self.definitions = definitions
 
@@ -37,3 +42,7 @@ class Spec:
 
     def add_paths(self, paths):
         self.paths = paths
+
+    @property
+    def as_dict(self):
+        return self.__dict__

--- a/sanic_openapi/spec.py
+++ b/sanic_openapi/spec.py
@@ -2,10 +2,9 @@ from sanic import Sanic
 
 
 class Spec:
-    swagger = "2.0"
-
     def __init__(self, app: Sanic) -> None:
-        self.swagger = self.__class__.swagger
+        self.swagger = "2.0"
+
         self.info = {
             "version": getattr(app.config, "API_VERSION", "1.0.0"),
             "title": getattr(app.config, "API_TITLE", "API"),

--- a/sanic_openapi/swagger.py
+++ b/sanic_openapi/swagger.py
@@ -260,7 +260,7 @@ def build_spec(app, loop):
 @swagger_blueprint.route("/swagger.json")
 @doc_route(exclude=True)
 def spec(request):
-    return json(swagger_blueprint._spec)
+    return json(swagger_blueprint._spec.as_dict)
 
 
 @swagger_blueprint.route("/swagger-config")


### PR DESCRIPTION
#155 
Bug was on Windows, because ujson can dump Spec class to JSON but json can not.