### PR TITLE
Release 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 0.6.2 (2020-06-01)
+
+### Features
+
+* Model inheritance ([0aa81c](https://github.com/huge-success/sanic-openapi/commit/0aa81c83754767c78444c3d01d548305858d8a22))
+
+### Bug Fixes
+
+* TypeError when Spec obj is not JSON serializable ([fe29d0](https://github.com/huge-success/sanic-openapi/commit/fe29d07ccb0e02ec0be6496e971946269b2d7907))
+* Attribute name "name" conflict in consumes body ([67aaf3](https://github.com/huge-success/sanic-openapi/commit/67aaf34eca5e339c349ef65bd0392cb8a97f184e))
+
 ### 0.6.1 (2020-01-03)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,3 +106,8 @@ If you want to make a Pull Request, here are some suggestions:
 1. Check other pull requests first, make sure your contributions are not duplicate to others.
 2. Run all tests at your machine, make sure your contributions are works and does not break anything.
 3. Document and example will be very appreciated.
+
+
+## Release Process
+
+We will have two scheduled releases in January and July to make sure we can support all the LTS versions of Sanic. And if there is any other release request for new features or fixes, please open a new issue, we can consider accepting this request.

--- a/sanic_openapi/__init__.py
+++ b/sanic_openapi/__init__.py
@@ -1,4 +1,4 @@
 from .swagger import swagger_blueprint
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 __all__ = ["swagger_blueprint"]


### PR DESCRIPTION
Hi @ahopkins, May I ask your help to release new version of `sanic-openapi`? This release will fix the `not JSON serializable` issue caused by `usjon>=2`.