### PR TITLE
Align python version with sanic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ cache:
   - pip
 matrix:
   include:
-    - python: 3.5
     - python: 3.6
     - python: 3.7
       dist: xenial
       sudo: true
+    - python: 3.8
 install:
   - pip install tox-travis
   - pip install codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py35-sanic{lts, 19.03.1}, {py36, py37}-sanic{lts, 19.03.1, 19.06.0, 19.09.0}, check
+envlist = {py36,py37,py38}-sanic{lts, 19.03.1, 19.06.0, 19.09.0, 20.03.0}, check
 
 
 [travis]
 python =
-    3.5: py35
     3.6: py36, check
     3.7: py37
+    3.8: py38
 
 
 [testenv]


### PR DESCRIPTION
## This PR

Removes py35
Add py38
Add sanic 20.3.0

## Note

Sanic does not support Python 3.5 from version 19.6 and forward. However, version 18.12LTS is supported thru December 2020. Official Python support for version 3.5 is set to expire in September 2020.

