### PR TITLE
Adding Description field to Parameter

### DIFF
--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -302,11 +302,11 @@ def description(text):
     return inner
 
 
-def consumes(*args, content_type=None, location="query", required=False):
+def consumes(*args, content_type=None, location="query", required=False, description=None):
     def inner(func):
         if args:
             for arg in args:
-                field = RouteField(arg, location, required)
+                field = RouteField(arg, location, required, description=description)
                 route_specs[func].consumes.append(field)
                 route_specs[func].consumes_content_type = [content_type]
         return func

--- a/sanic_openapi/swagger.py
+++ b/sanic_openapi/swagger.py
@@ -177,8 +177,7 @@ def build_spec(app, loop):
                         **spec,
                         "required": consumer.required,
                         "in": consumer.location,
-                        "name": consumer.field.name,
-                        "description": consumer.field.description
+                        "name": consumer.field.name
                         if not isinstance(consumer.field, type)
                         and hasattr(consumer.field, "name")
                         else "body",

--- a/sanic_openapi/swagger.py
+++ b/sanic_openapi/swagger.py
@@ -170,13 +170,15 @@ def build_spec(app, loop):
                             "required": consumer.required,
                             "in": consumer.location,
                             "name": name,
+                            "description": consumer.description,
                         }
                 else:
                     route_param = {
                         **spec,
                         "required": consumer.required,
                         "in": consumer.location,
-                        "name": consumer.field.name
+                        "name": consumer.field.name,
+                        "description": consumer.field.description
                         if not isinstance(consumer.field, type)
                         and hasattr(consumer.field, "name")
                         else "body",


### PR DESCRIPTION
Even though RouteField takes optional description, "consumes" doesnt allow user to set parameter description.
This change addresses this issue and reflect this on the UI.

Example:
[@doc.consumes({'Authorization':](url) str}, location='header', required=True,
description="User's authorization token")
